### PR TITLE
update: handles cases where api returns null on DNSRecordSchema

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ const DNSRecordSchema = z.object({
   name: z.string(),
   content: z.string(),
   proxied: z.boolean(),
-  comment: z.string().nullable().optional(),
+  comment: z.string().nullish(),
 });
 
 // Type definitions (exported for potential external use)

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ const DNSRecordSchema = z.object({
   name: z.string(),
   content: z.string(),
   proxied: z.boolean(),
-  comment: z.string().optional(),
+  comment: z.string().nullable().optional(),
 });
 
 // Type definitions (exported for potential external use)


### PR DESCRIPTION
When configuring the tunnel via cloudflare ui, the api returns null for the DnsRecord schema, this PR updates the zod schema to handle this case.