### PR TITLE
Design API key management for discord bot

### DIFF
--- a/examples/discord-cursor-bot-example/API_KEY_DESIGN.md
+++ b/examples/discord-cursor-bot-example/API_KEY_DESIGN.md
@@ -89,26 +89,18 @@ export class ApiKeyManager {
 
 #### New Discord Commands
 
-**User API Key Management:**
+**Unified API Key Management:**
 ```
-/agents set-user-api-key
-  - Sets API key for the requesting user
+/agents set-api-key [type: user|channel]
+  - type: user - Sets API key for the requesting user
+  - type: channel - Sets API key for current channel
   - Uses Discord Modal for secure input
-  - Stored with user ID as key
+  - Channel type requires appropriate Discord permissions
 
-/agents remove-user-api-key
-  - Removes the requesting user's API key
-  - Confirmation prompt
-```
-
-**Enhanced Channel Commands:**
-```
-/agents set-api-key (existing, unchanged)
-  - Sets API key for current channel
-
-/agents remove-api-key
-  - Removes channel API key
-  - Admin/manage channel permission required
+/agents remove-api-key [type: user|channel]
+  - type: user - Removes the requesting user's API key
+  - type: channel - Removes channel API key (requires permissions)
+  - Confirmation prompt for safety
 ```
 
 **Status/Info Commands:**
@@ -228,14 +220,14 @@ No database schema changes required - all API keys are stored in Cloudflare KV.
 
 #### Scenario 1: Team Channel with Individual Overrides
 ```
-Channel #dev-team:
-- Channel API Key: team_key_123
-- Alice has user API key: alice_key_456
-- Bob uses channel key (no personal key)
+Setup Commands:
+- Admin runs: /agents set-api-key type:channel → Sets team_key_123
+- Alice runs: /agents set-api-key type:user → Sets alice_key_456
+- Bob has no personal key (uses channel key)
 
 Agent Creation:
-- Alice runs /task "fix bug" → Uses alice_key_456
-- Bob runs /task "add feature" → Uses team_key_123
+- Alice runs /task "fix bug" → Uses alice_key_456 (user key priority)
+- Bob runs /task "add feature" → Uses team_key_123 (channel key)
 
 Thread Replies:
 - In Alice's agent thread, Bob replies → Uses team_key_123 (channel first)
@@ -244,9 +236,9 @@ Thread Replies:
 
 #### Scenario 2: Personal Channel
 ```
-Channel #alice-sandbox:
-- No channel API key set
-- Alice has user API key: alice_key_456
+Setup Commands:
+- Alice runs: /agents set-api-key type:user → Sets alice_key_456
+- No channel key set
 
 Agent Creation:
 - Alice runs /task "experiment" → Uses alice_key_456
@@ -259,10 +251,10 @@ Thread Replies:
 
 #### Scenario 3: Thread with Multiple Users
 ```
-Channel #collaboration:
-- Channel API Key: collab_key_789
-- Alice has user API key: alice_key_456
-- Bob has user API key: bob_key_123
+Setup Commands:
+- Admin runs: /agents set-api-key type:channel → Sets collab_key_789
+- Alice runs: /agents set-api-key type:user → Sets alice_key_456
+- Bob runs: /agents set-api-key type:user → Sets bob_key_123
 
 Agent Creation:
 - Alice runs /agents create "project setup" → Uses alice_key_456

--- a/examples/discord-cursor-bot-example/API_KEY_DESIGN.md
+++ b/examples/discord-cursor-bot-example/API_KEY_DESIGN.md
@@ -1,0 +1,278 @@
+# API Key Management Design Proposal
+
+## Overview
+
+This document proposes an enhanced API key management system for the Cursor Discord Bot that allows users to save API keys either for themselves (by user ID) or for a channel. The system implements a hierarchical resolution strategy for determining which API key to use when running agents.
+
+## Current State
+
+The current implementation only supports channel-level API keys stored in Cloudflare KV with the pattern:
+- **Storage Key**: `channel:{channelId}:api_key`
+- **Resolution**: Channel key → Default fallback key
+
+## Proposed Changes
+
+### 1. Enhanced Storage Schema
+
+#### User API Keys
+- **Storage Key**: `user:{userId}:api_key`
+- **Data Structure**:
+```typescript
+interface UserApiKey {
+  userId: string;
+  apiKey: string;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+#### Channel API Keys (Enhanced)
+- **Storage Key**: `channel:{channelId}:api_key` (unchanged)
+- **Data Structure** (unchanged):
+```typescript
+interface ChannelApiKey {
+  channelId: string;
+  apiKey: string;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### 2. API Key Resolution Logic
+
+#### For Regular Agent Creation (Slash Commands)
+**Priority Order:**
+1. **Requesting User's API Key** (`user:{userId}:api_key`)
+2. **Channel API Key** (`channel:{channelId}:api_key`)
+3. **Default/Fallback API Key** (environment variable)
+
+#### For Thread Replies (Follow-up Messages)
+**Priority Order:**
+1. **Channel API Key** (`channel:{channelId}:api_key`)
+2. **Last Reply User's API Key** (`user:{lastReplyUserId}:api_key`)
+3. **Default/Fallback API Key** (environment variable)
+
+**Note**: For thread replies, we prioritize the channel key first, then check the user ID of the *last reply in the thread only* (not the original requester).
+
+### 3. Implementation Details
+
+#### Enhanced API Key Manager
+
+```typescript
+export class ApiKeyManager {
+  constructor(private readonly kv: KVNamespace) {}
+
+  // User API key methods
+  async setUserApiKey(userId: string, apiKey: string): Promise<void>
+  async getUserApiKey(userId: string): Promise<string | null>
+  async deleteUserApiKey(userId: string): Promise<void>
+
+  // Channel API key methods (existing)
+  async setApiKey(channelId: string, apiKey: string): Promise<void>
+  async getApiKey(channelId: string): Promise<string | null>
+  async deleteApiKey(channelId: string): Promise<void>
+
+  // Enhanced resolution methods
+  async resolveApiKeyForAgent(
+    channelId: string, 
+    userId: string, 
+    defaultApiKey?: string
+  ): Promise<string | null>
+
+  async resolveApiKeyForThread(
+    channelId: string, 
+    lastReplyUserId: string, 
+    defaultApiKey?: string
+  ): Promise<string | null>
+}
+```
+
+#### New Discord Commands
+
+**User API Key Management:**
+```
+/agents set-user-api-key
+  - Sets API key for the requesting user
+  - Uses Discord Modal for secure input
+  - Stored with user ID as key
+
+/agents remove-user-api-key
+  - Removes the requesting user's API key
+  - Confirmation prompt
+```
+
+**Enhanced Channel Commands:**
+```
+/agents set-api-key (existing, unchanged)
+  - Sets API key for current channel
+
+/agents remove-api-key
+  - Removes channel API key
+  - Admin/manage channel permission required
+```
+
+**Status/Info Commands:**
+```
+/agents api-key-status
+  - Shows which API key would be used (without revealing the key)
+  - Example output:
+    "✅ User API Key (your personal key will be used)"
+    "🏢 Channel API Key (channel key will be used)" 
+    "🔄 Default API Key (fallback key will be used)"
+    "❌ No API Key Available"
+```
+
+#### Thread Reply Enhancement
+
+**Current Thread Handler Changes:**
+```typescript
+class ThreadInteractionHandler {
+  private async createFollowUpMessage(
+    agentId: string, 
+    followUpMessage: string, 
+    lastReplyUserId: string,  // Changed: now tracks last reply user
+    threadId: string
+  ): Promise<void> {
+    // Get agent details to find parent channel
+    const agent = await this.getAgentById(agentId);
+    const channelId = agent.discordChannelId;
+
+    // NEW: Use thread-specific resolution logic
+    const apiKeyManager = createApiKeyManager(this.env.API_KEYS);
+    const apiKey = await apiKeyManager.resolveApiKeyForThread(
+      channelId, 
+      lastReplyUserId,  // Use last reply user, not original requester
+      this.env.CURSOR_API_KEY
+    );
+
+    // ... rest of the method unchanged
+  }
+
+  private getLastReplyUserId(messages: Array<any>): string {
+    // Find the last non-bot message in the thread
+    const sortedMessages = messages.sort((a, b) => 
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+    
+    const lastUserMessage = sortedMessages.find(msg => !msg.author.bot);
+    return lastUserMessage?.author.id || '';
+  }
+}
+```
+
+### 4. Database Schema Changes
+
+No database schema changes required - all API keys are stored in Cloudflare KV.
+
+### 5. Security Considerations
+
+#### Key Isolation
+- User keys are completely isolated by user ID
+- Channel keys are isolated by channel ID
+- No cross-contamination possible
+
+#### Access Control
+- Users can only set/remove their own API keys
+- Channel API key management requires appropriate Discord permissions
+- All API key operations use Discord Modals for secure input
+
+#### Key Validation
+- All API keys are validated against Cursor API before storage
+- Invalid keys are rejected with clear error messages
+- Validation happens on both user and channel key operations
+
+### 6. User Experience
+
+#### Clear Feedback
+- Commands show which type of API key will be used
+- Status command reveals the resolution hierarchy
+- Error messages clearly indicate missing API key type
+
+#### Flexible Configuration
+- Teams can use channel keys for shared access
+- Individual users can override with personal keys
+- Fallback to default key ensures system reliability
+
+#### Thread Context Awareness
+- Thread replies respect channel-first policy
+- Last replier's context is preserved
+- Clear indication of which key is being used
+
+### 7. Migration Strategy
+
+#### Backward Compatibility
+- All existing channel API keys continue to work
+- No breaking changes to existing commands
+- Gradual rollout of new features
+
+#### Migration Steps
+1. Deploy enhanced API key manager
+2. Add new user API key commands
+3. Update thread handler logic
+4. Add status/info commands
+5. Update documentation and examples
+
+### 8. Implementation Files
+
+#### New Files
+- `src/types.ts` - Add `UserApiKey` interface
+- Enhanced `src/api-key-manager.ts` - New resolution methods
+- Updated `src/discord-commands.ts` - New command definitions
+
+#### Modified Files
+- `src/worker.ts` - New command handlers
+- `src/thread-interaction-handler.ts` - Updated resolution logic
+- `README.md` - Updated documentation
+
+### 9. Example Usage Scenarios
+
+#### Scenario 1: Team Channel with Individual Overrides
+```
+Channel #dev-team:
+- Channel API Key: team_key_123
+- Alice has user API key: alice_key_456
+- Bob uses channel key (no personal key)
+
+Agent Creation:
+- Alice runs /task "fix bug" → Uses alice_key_456
+- Bob runs /task "add feature" → Uses team_key_123
+
+Thread Replies:
+- In Alice's agent thread, Bob replies → Uses team_key_123 (channel first)
+- In Bob's agent thread, Alice replies → Uses team_key_123 (channel first)
+```
+
+#### Scenario 2: Personal Channel
+```
+Channel #alice-sandbox:
+- No channel API key set
+- Alice has user API key: alice_key_456
+
+Agent Creation:
+- Alice runs /task "experiment" → Uses alice_key_456
+- Bob runs /task "help" → ❌ No API key available
+
+Thread Replies:
+- In Alice's thread, Alice replies → Uses alice_key_456
+- In Alice's thread, Bob replies → ❌ No API key available
+```
+
+#### Scenario 3: Thread with Multiple Users
+```
+Channel #collaboration:
+- Channel API Key: collab_key_789
+- Alice has user API key: alice_key_456
+- Bob has user API key: bob_key_123
+
+Agent Creation:
+- Alice runs /agents create "project setup" → Uses alice_key_456
+
+Thread Activity:
+1. Alice replies "add tests" → Uses collab_key_789 (channel first)
+2. Bob replies "fix linting" → Uses collab_key_789 (channel first) 
+3. Charlie (no personal key) replies "deploy" → Uses collab_key_789
+
+Note: All thread replies use channel key since it's available
+```
+
+This design provides maximum flexibility while maintaining clear, predictable behavior for both individual and team usage scenarios.

--- a/examples/discord-cursor-bot-example/IMPLEMENTATION_SUMMARY.md
+++ b/examples/discord-cursor-bot-example/IMPLEMENTATION_SUMMARY.md
@@ -1,0 +1,157 @@
+# Implementation Summary: Enhanced API Key Management
+
+## Key Changes Required
+
+### 1. Types Enhancement (`src/types.ts`)
+
+Add new interface for user API keys:
+
+```typescript
+export interface UserApiKey {
+  userId: string;
+  apiKey: string;
+  createdAt: string;
+  updatedAt: string;
+}
+```
+
+### 2. API Key Manager Enhancement (`src/api-key-manager.ts`)
+
+Add new methods to the `ApiKeyManager` class:
+
+```typescript
+// User API key methods
+async setUserApiKey(userId: string, apiKey: string): Promise<void>
+async getUserApiKey(userId: string): Promise<string | null>
+async deleteUserApiKey(userId: string): Promise<void>
+
+// Enhanced resolution methods
+async resolveApiKeyForAgent(channelId: string, userId: string, defaultApiKey?: string): Promise<string | null>
+async resolveApiKeyForThread(channelId: string, lastReplyUserId: string, defaultApiKey?: string): Promise<string | null>
+```
+
+**Storage Pattern for User Keys**: `user:{userId}:api_key`
+
+### 3. Discord Commands (`src/discord-commands.ts`)
+
+Add new subcommands to the `/agents` command:
+
+```typescript
+{
+  type: ApplicationCommandOptionType.SUB_COMMAND,
+  name: 'set-user-api-key',
+  description: 'Set your personal Cursor API key',
+  options: []
+},
+{
+  type: ApplicationCommandOptionType.SUB_COMMAND,
+  name: 'remove-user-api-key', 
+  description: 'Remove your personal Cursor API key',
+  options: []
+},
+{
+  type: ApplicationCommandOptionType.SUB_COMMAND,
+  name: 'api-key-status',
+  description: 'Check which API key would be used',
+  options: []
+}
+```
+
+### 4. Worker Command Handlers (`src/worker.ts`)
+
+Add handlers for new commands:
+
+```typescript
+case 'set-user-api-key':
+  response = await handleSetUserApiKey(interaction, userId, env);
+  break;
+case 'remove-user-api-key':
+  response = await handleRemoveUserApiKey(interaction, userId, env);
+  break;
+case 'api-key-status':
+  response = await handleApiKeyStatus(interaction, channelId, userId, env);
+  break;
+```
+
+Update existing agent creation to use new resolution:
+
+```typescript
+// Replace getEffectiveApiKey calls with:
+const apiKey = await keyManager.resolveApiKeyForAgent(channelId, userId, env.CURSOR_API_KEY);
+```
+
+### 5. Thread Handler Enhancement (`src/thread-interaction-handler.ts`)
+
+**Critical Change**: Update thread reply handling to use the last reply user ID and channel-first resolution:
+
+```typescript
+private async createFollowUpMessage(
+  agentId: string, 
+  followUpMessage: string, 
+  lastReplyUserId: string,  // Changed parameter
+  threadId: string
+): Promise<void> {
+  // Get parent channel from agent
+  const agent = await this.getAgentById(agentId);
+  const channelId = agent.discordChannelId;
+
+  // Use thread-specific resolution (channel first, then last reply user)
+  const apiKeyManager = createApiKeyManager(this.env.API_KEYS);
+  const apiKey = await apiKeyManager.resolveApiKeyForThread(
+    channelId, 
+    lastReplyUserId,
+    this.env.CURSOR_API_KEY
+  );
+  
+  // ... rest unchanged
+}
+
+// Update caller to pass last reply user ID
+public async handleThreadInteraction(interaction: ThreadInteraction): Promise<Response> {
+  const lastReplyUserId = this.getLastReplyUserId(interaction.messages);
+  
+  await this.createFollowUpMessage(
+    agentId, 
+    combinedMessage, 
+    lastReplyUserId,  // Changed: use last reply user, not triggering message user
+    interaction.thread.id
+  );
+}
+
+private getLastReplyUserId(messages: Array<any>): string {
+  const sortedMessages = messages.sort((a, b) => 
+    new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  );
+  
+  const lastUserMessage = sortedMessages.find(msg => !msg.author.bot);
+  return lastUserMessage?.author.id || '';
+}
+```
+
+## Resolution Logic Summary
+
+### For Agent Creation (Slash Commands):
+1. User's personal API key
+2. Channel API key  
+3. Default/fallback API key
+
+### For Thread Replies:
+1. Channel API key
+2. Last reply user's API key
+3. Default/fallback API key
+
+## Backward Compatibility
+
+- All existing channel API keys continue to work unchanged
+- Existing commands remain functional
+- New features are additive, no breaking changes
+
+## Security Features
+
+- User keys isolated by Discord user ID
+- Channel keys isolated by Discord channel ID
+- All API key input via secure Discord Modals
+- API key validation before storage
+- Clear error messages for missing keys
+
+This implementation provides flexible API key management while maintaining the specific thread reply behavior requested (channel-first, then last reply user).

--- a/examples/discord-cursor-bot-example/IMPLEMENTATION_SUMMARY.md
+++ b/examples/discord-cursor-bot-example/IMPLEMENTATION_SUMMARY.md
@@ -34,20 +34,43 @@ async resolveApiKeyForThread(channelId: string, lastReplyUserId: string, default
 
 ### 3. Discord Commands (`src/discord-commands.ts`)
 
-Add new subcommands to the `/agents` command:
+**Update existing `set-api-key` subcommand** to include type parameter:
 
 ```typescript
 {
   type: ApplicationCommandOptionType.SUB_COMMAND,
-  name: 'set-user-api-key',
-  description: 'Set your personal Cursor API key',
-  options: []
-},
+  name: 'set-api-key',
+  description: 'Set Cursor API key for user or channel',
+  options: [{
+    type: ApplicationCommandOptionType.STRING,
+    name: 'type',
+    description: 'Set API key for user or channel',
+    required: true,
+    choices: [
+      { name: 'User (Personal API Key)', value: 'user' },
+      { name: 'Channel (Shared API Key)', value: 'channel' }
+    ]
+  }]
+}
+```
+
+**Add new subcommands**:
+
+```typescript
 {
   type: ApplicationCommandOptionType.SUB_COMMAND,
-  name: 'remove-user-api-key', 
-  description: 'Remove your personal Cursor API key',
-  options: []
+  name: 'remove-api-key',
+  description: 'Remove Cursor API key for user or channel',
+  options: [{
+    type: ApplicationCommandOptionType.STRING,
+    name: 'type',
+    description: 'Remove API key for user or channel',
+    required: true,
+    choices: [
+      { name: 'User (Personal API Key)', value: 'user' },
+      { name: 'Channel (Shared API Key)', value: 'channel' }
+    ]
+  }]
 },
 {
   type: ApplicationCommandOptionType.SUB_COMMAND,
@@ -59,18 +82,45 @@ Add new subcommands to the `/agents` command:
 
 ### 4. Worker Command Handlers (`src/worker.ts`)
 
-Add handlers for new commands:
+**Update existing handler** to support type parameter:
 
 ```typescript
-case 'set-user-api-key':
-  response = await handleSetUserApiKey(interaction, userId, env);
+case 'set-api-key':
+  const apiKeyType = subcommand.options?.find((opt: any) => opt.name === 'type')?.value;
+  response = await handleSetApiKey(interaction, channelId, userId, apiKeyType, env);
   break;
-case 'remove-user-api-key':
-  response = await handleRemoveUserApiKey(interaction, userId, env);
+```
+
+**Add new handlers**:
+
+```typescript
+case 'remove-api-key':
+  const removeType = subcommand.options?.find((opt: any) => opt.name === 'type')?.value;
+  response = await handleRemoveApiKey(interaction, channelId, userId, removeType, env);
   break;
 case 'api-key-status':
   response = await handleApiKeyStatus(interaction, channelId, userId, env);
   break;
+```
+
+**Updated Handler Function Signatures**:
+
+```typescript
+async function handleSetApiKey(
+  interaction: any,
+  channelId: string,
+  userId: string,
+  type: 'user' | 'channel',
+  env: Env
+): Promise<InteractionResponse>
+
+async function handleRemoveApiKey(
+  interaction: any,
+  channelId: string,
+  userId: string,
+  type: 'user' | 'channel',
+  env: Env
+): Promise<InteractionResponse>
 ```
 
 Update existing agent creation to use new resolution:

--- a/examples/discord-cursor-bot-example/package-lock.json
+++ b/examples/discord-cursor-bot-example/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@cloudflare/vite-plugin": "^1.10.2",
         "internal-rules": "file:./rules",
+        "typescript": "^5.9.2",
         "vite": "^7.0.0",
         "vite-plugin-cloudflare-tunnel": "file:../..",
         "wrangler": "^4.0.0"
@@ -21,7 +22,7 @@
     },
     "../..": {
       "name": "vite-plugin-cloudflare-tunnel",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2130,6 +2131,20 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
       "license": "Unlicense"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/ufo": {
       "version": "1.6.1",

--- a/examples/discord-cursor-bot-example/package.json
+++ b/examples/discord-cursor-bot-example/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.10.2",
     "internal-rules": "file:./rules",
+    "typescript": "^5.9.2",
     "vite": "^7.0.0",
     "vite-plugin-cloudflare-tunnel": "file:../..",
     "wrangler": "^4.0.0"

--- a/examples/discord-cursor-bot-example/src/api-key-manager.ts
+++ b/examples/discord-cursor-bot-example/src/api-key-manager.ts
@@ -4,7 +4,7 @@
  * Each Discord channel can have its own API key for team isolation.
  */
 
-import type { ChannelApiKey } from './types';
+import type { ChannelApiKey, UserApiKey } from './types';
 import { CursorApiService } from './cursor-service';
 
 /**
@@ -75,6 +75,65 @@ export class ApiKeyManager {
     await this.kv.delete(storageKey);
     
     console.log(`🗑️ Deleted API key for channel ${channelId}`);
+  }
+
+  /**
+   * Store a Cursor API key for a specific Discord user
+   */
+  async setUserApiKey(userId: string, apiKey: string): Promise<void> {
+    if (!userId || !apiKey) {
+      throw new Error('User ID and API key are required');
+    }
+
+    const keyData: UserApiKey = {
+      userId,
+      apiKey,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const storageKey = this.getUserStorageKey(userId);
+    await this.kv.put(storageKey, JSON.stringify(keyData));
+    
+    console.log(`🔑 Stored user API key for user ${userId}`);
+  }
+
+  /**
+   * Retrieve the Cursor API key for a specific Discord user
+   */
+  async getUserApiKey(userId: string): Promise<string | null> {
+    if (!userId) {
+      return null;
+    }
+
+    const storageKey = this.getUserStorageKey(userId);
+    const data = await this.kv.get(storageKey);
+    
+    if (!data) {
+      return null;
+    }
+
+    try {
+      const keyData = JSON.parse(data) as UserApiKey;
+      return keyData.apiKey;
+    } catch (error) {
+      console.error(`❌ Error parsing user API key data for user ${userId}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Delete the API key for a specific Discord user
+   */
+  async deleteUserApiKey(userId: string): Promise<void> {
+    if (!userId) {
+      return;
+    }
+
+    const storageKey = this.getUserStorageKey(userId);
+    await this.kv.delete(storageKey);
+    
+    console.log(`🗑️ Deleted user API key for user ${userId}`);
   }
 
   /**
@@ -163,6 +222,79 @@ export class ApiKeyManager {
    */
   private getStorageKey(channelId: string): string {
     return `channel:${channelId}:api_key`;
+  }
+
+  /**
+   * Generate the KV storage key for a user's API key
+   */
+  private getUserStorageKey(userId: string): string {
+    return `user:${userId}:api_key`;
+  }
+
+  /**
+   * Resolve API key for agent creation (user key priority)
+   * Priority: User key → Channel key → Default key
+   */
+  async resolveApiKeyForAgent(
+    channelId: string, 
+    userId: string, 
+    defaultApiKey?: string
+  ): Promise<string | null> {
+    // First try user's personal API key
+    const userApiKey = await this.getUserApiKey(userId);
+    if (userApiKey) {
+      console.log(`🔑 Using user API key for user ${userId}`);
+      return userApiKey;
+    }
+
+    // Then try channel API key
+    const channelApiKey = await this.getApiKey(channelId);
+    if (channelApiKey) {
+      console.log(`🏢 Using channel API key for channel ${channelId}`);
+      return channelApiKey;
+    }
+
+    // Finally fall back to default API key
+    if (defaultApiKey) {
+      console.log(`🔄 Using default API key for channel ${channelId}, user ${userId}`);
+      return defaultApiKey;
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolve API key for thread replies (channel key priority)
+   * Priority: Channel key → Last reply user's key → Default key
+   */
+  async resolveApiKeyForThread(
+    channelId: string, 
+    lastReplyUserId: string, 
+    defaultApiKey?: string
+  ): Promise<string | null> {
+    // First try channel API key (team collaboration priority)
+    const channelApiKey = await this.getApiKey(channelId);
+    if (channelApiKey) {
+      console.log(`🏢 Using channel API key for thread in channel ${channelId}`);
+      return channelApiKey;
+    }
+
+    // Then try last reply user's API key
+    if (lastReplyUserId) {
+      const userApiKey = await this.getUserApiKey(lastReplyUserId);
+      if (userApiKey) {
+        console.log(`🔑 Using last reply user API key for user ${lastReplyUserId}`);
+        return userApiKey;
+      }
+    }
+
+    // Finally fall back to default API key
+    if (defaultApiKey) {
+      console.log(`🔄 Using default API key for thread in channel ${channelId}`);
+      return defaultApiKey;
+    }
+
+    return null;
   }
 }
 

--- a/examples/discord-cursor-bot-example/src/discord-commands.ts
+++ b/examples/discord-cursor-bot-example/src/discord-commands.ts
@@ -35,8 +35,17 @@ export const AGENT_COMMANDS = {
     {
       type: ApplicationCommandOptionType.SUB_COMMAND,
       name: 'set-api-key',
-      description: 'Set Cursor API key for this channel (secure modal input)',
-      options: [] // No parameters - uses Discord Modal for secure input
+      description: 'Set Cursor API key for user or channel',
+      options: [{
+        type: ApplicationCommandOptionType.STRING,
+        name: 'type',
+        description: 'Set API key for user or channel',
+        required: true,
+        choices: [
+          { name: 'User (Personal API Key)', value: 'user' },
+          { name: 'Channel (Shared API Key)', value: 'channel' }
+        ]
+      }]
     },
     {
       type: ApplicationCommandOptionType.SUB_COMMAND,
@@ -86,6 +95,27 @@ export const AGENT_COMMANDS = {
         description: 'GitHub repository URL (e.g., https://github.com/org/repo)',
         required: true
       }]
+    },
+    {
+      type: ApplicationCommandOptionType.SUB_COMMAND,
+      name: 'remove-api-key',
+      description: 'Remove Cursor API key for user or channel',
+      options: [{
+        type: ApplicationCommandOptionType.STRING,
+        name: 'type',
+        description: 'Remove API key for user or channel',
+        required: true,
+        choices: [
+          { name: 'User (Personal API Key)', value: 'user' },
+          { name: 'Channel (Shared API Key)', value: 'channel' }
+        ]
+      }]
+    },
+    {
+      type: ApplicationCommandOptionType.SUB_COMMAND,
+      name: 'api-key-status',
+      description: 'Check which API key would be used',
+      options: []
     }
   ]
 } as const;
@@ -159,6 +189,8 @@ export const AGENTS_SUBCOMMANDS = {
   CREATE: 'create',
   LIST: 'list',
   SET_DEFAULT_REPO: 'set-default-repo',
+  REMOVE_API_KEY: 'remove-api-key',
+  API_KEY_STATUS: 'api-key-status',
 } as const;
 
 /**

--- a/examples/discord-cursor-bot-example/src/thread-interaction-handler.ts
+++ b/examples/discord-cursor-bot-example/src/thread-interaction-handler.ts
@@ -6,7 +6,7 @@
 
 import { CursorApiService } from './cursor-service';
 import { ThreadManager } from './thread-manager';
-import { ApiKeyManager, createApiKeyManager, getEffectiveApiKey } from './api-key-manager';
+import { ApiKeyManager, createApiKeyManager } from './api-key-manager';
 import type { 
   Env, 
   ThreadInteraction, 
@@ -40,7 +40,9 @@ export class ThreadInteractionHandler {
 
       // Get all user messages since the last bot message
       const followUpMessages = this.getMessagesSinceLastBot(interaction.messages);
-      const userId = interaction.triggering_message.author.id;
+      
+      // Get the last reply user ID (for API key resolution)
+      const lastReplyUserId = this.getLastReplyUserId(interaction.messages);
 
       // Skip if no meaningful user messages found
       if (followUpMessages.length === 0) {
@@ -77,7 +79,7 @@ export class ThreadInteractionHandler {
       await this.createFollowUpMessage(
         agentId, 
         combinedMessage, 
-        userId, 
+        lastReplyUserId, 
         interaction.thread.id
       );
 
@@ -155,6 +157,20 @@ export class ThreadInteractionHandler {
   }
 
   /**
+   * Get the user ID of the last non-bot message in the thread
+   */
+  private getLastReplyUserId(messages: Array<any>): string {
+    // Sort messages by creation time (newest first)
+    const sortedMessages = messages.sort((a, b) => 
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+    );
+    
+    // Find the last user message (not bot message)
+    const lastUserMessage = sortedMessages.find(msg => !msg.author.bot);
+    return lastUserMessage?.author.id || '';
+  }
+
+  /**
    * Combine multiple follow-up messages into a single coherent message
    */
   private combineFollowUpMessages(messages: Array<any>): string {
@@ -205,9 +221,13 @@ export class ThreadInteractionHandler {
 
       console.log(`📋 Found agent: ${agent.id} in channel ${agent.discordChannelId}`);
 
-      // Get API key for the channel
+      // Get API key using thread-specific resolution logic
       const apiKeyManager = createApiKeyManager(this.env.API_KEYS);
-      const apiKey = await getEffectiveApiKey(agent.discordChannelId, apiKeyManager, this.env.CURSOR_API_KEY);
+      const apiKey = await apiKeyManager.resolveApiKeyForThread(
+        agent.discordChannelId, 
+        userId, 
+        this.env.CURSOR_API_KEY
+      );
       
       if (!apiKey) {
         throw new Error('No API key available for this channel');

--- a/examples/discord-cursor-bot-example/src/types.ts
+++ b/examples/discord-cursor-bot-example/src/types.ts
@@ -93,6 +93,13 @@ export interface ChannelApiKey {
   updatedAt: string;
 }
 
+export interface UserApiKey {
+  userId: string;
+  apiKey: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 // Channel configuration for Discord integration
 export interface ChannelConfig {
   channelId: string;

--- a/examples/discord-cursor-bot-example/src/worker.ts
+++ b/examples/discord-cursor-bot-example/src/worker.ts
@@ -19,7 +19,7 @@ import { validateGitHubUrl, mapApiAgentToStoredAgent } from './type-mappers';
 import { ThreadManager, createThreadManager } from './thread-manager';
 import { handleCursorWebhook } from './webhook-handler';
 import { handleThreadInteraction } from './thread-interaction-handler';
-import { ApiKeyManager, createApiKeyManager, getEffectiveApiKey } from './api-key-manager';
+import { ApiKeyManager, createApiKeyManager } from './api-key-manager';
 import type { 
   Env, 
   InteractionResponse, 
@@ -367,22 +367,35 @@ async function handleSetApiKey(
   interaction: any,
   channelId: string, 
   userId: string, 
+  type: 'user' | 'channel',
   env: Env
 ): Promise<InteractionResponse> {
+  // Validate type parameter
+  if (type !== 'user' && type !== 'channel') {
+    return createErrorResponse('Invalid API key type. Must be "user" or "channel".');
+  }
+
+  const isUserKey = type === 'user';
+  const title = isUserKey ? 'Set Personal API Key' : 'Set Channel API Key';
+  const label = isUserKey ? 'Your Personal Cursor API Key' : 'Channel Cursor API Key';
+  const placeholder = isUserKey 
+    ? 'Enter your personal Cursor API key...' 
+    : 'Enter the shared Cursor API key for this channel...';
+
   // Show Discord Modal for secure API key input
   return {
     type: InteractionResponseType.MODAL,
     data: {
-      custom_id: `api_key_modal_${channelId}`,
-      title: 'Set Cursor API Key',
+      custom_id: `api_key_modal_${type}_${isUserKey ? userId : channelId}`,
+      title,
       components: [{
         type: 1, // ACTION_ROW
         components: [{
           type: 4, // TEXT_INPUT
           custom_id: 'api_key_input',
-          label: 'Cursor API Key',
+          label,
           style: 1, // SHORT
-          placeholder: 'Enter your Cursor API key...',
+          placeholder,
           required: true,
           max_length: 200
         }]
@@ -436,6 +449,16 @@ async function handleApiKeyModalSubmit(
     return createErrorResponse('API key is required');
   }
 
+  // Parse type from custom_id: api_key_modal_{type}_{id}
+  const customId = interaction.data.custom_id;
+  const parts = customId.split('_');
+  const type = parts[3]; // api_key_modal_{type}_{id}
+  const targetId = parts[4];
+
+  if (type !== 'user' && type !== 'channel') {
+    return createErrorResponse('Invalid API key type in modal submission');
+  }
+
   const keyManager = createApiKeyManager(env.API_KEYS);
   
   // Validate the API key
@@ -444,16 +467,26 @@ async function handleApiKeyModalSubmit(
     return createErrorResponse('Invalid API key. Please check your Cursor API key.');
   }
 
-  // Store the API key
-  await keyManager.setApiKey(channelId, apiKey);
-
-  return {
-    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
-    data: {
-      content: '✅ Cursor API key has been set for this channel!',
-      flags: 64, // Ephemeral
-    },
-  };
+  // Store the API key based on type
+  if (type === 'user') {
+    await keyManager.setUserApiKey(targetId, apiKey);
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: '✅ Your personal Cursor API key has been set!',
+        flags: 64, // Ephemeral
+      },
+    };
+  } else {
+    await keyManager.setApiKey(targetId, apiKey);
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: '✅ Cursor API key has been set for this channel!',
+        flags: 64, // Ephemeral
+      },
+    };
+  }
 }
 
 /**
@@ -518,9 +551,9 @@ async function handleCreateAgent(
     return createErrorResponse('Repository must be a valid GitHub URL (e.g., https://github.com/org/repo)');
   }
 
-  // Get API key for this channel
+  // Get API key using agent creation resolution logic
   const keyManager = createApiKeyManager(env.API_KEYS);
-  const apiKey = await getEffectiveApiKey(channelId, keyManager, env.CURSOR_API_KEY);
+  const apiKey = await keyManager.resolveApiKeyForAgent(channelId, userId, env.CURSOR_API_KEY);
 
   if (!apiKey) {
     return createErrorResponseWithButton(
@@ -611,7 +644,7 @@ async function handleTaskCommand(
   }
 
   const keyManager = createApiKeyManager(env.API_KEYS);
-  const apiKey = await getEffectiveApiKey(channelId, keyManager, env.CURSOR_API_KEY);
+  const apiKey = await keyManager.resolveApiKeyForAgent(channelId, userId, env.CURSOR_API_KEY);
 
   if (!apiKey) {
     return createErrorResponseWithButton(
@@ -637,6 +670,127 @@ async function handleTaskCommand(
 }
 
 /**
+ * Handle /agents remove-api-key command
+ */
+async function handleRemoveApiKey(
+  interaction: any,
+  channelId: string,
+  userId: string,
+  type: 'user' | 'channel',
+  env: Env
+): Promise<InteractionResponse> {
+  // Validate type parameter
+  if (type !== 'user' && type !== 'channel') {
+    return createErrorResponse('Invalid API key type. Must be "user" or "channel".');
+  }
+
+  const keyManager = createApiKeyManager(env.API_KEYS);
+  
+  if (type === 'user') {
+    // Check if user has an API key
+    const userApiKey = await keyManager.getUserApiKey(userId);
+    if (!userApiKey) {
+      return createErrorResponse('You don\'t have a personal API key set.');
+    }
+
+    // Remove user API key
+    await keyManager.deleteUserApiKey(userId);
+    
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: '✅ Your personal Cursor API key has been removed.',
+        flags: 64, // Ephemeral
+      },
+    };
+  } else {
+    // Check if channel has an API key
+    const channelApiKey = await keyManager.getApiKey(channelId);
+    if (!channelApiKey) {
+      return createErrorResponse('This channel doesn\'t have an API key set.');
+    }
+
+    // Remove channel API key
+    await keyManager.deleteApiKey(channelId);
+    
+    return {
+      type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+      data: {
+        content: '✅ The Cursor API key for this channel has been removed.',
+        flags: 64, // Ephemeral
+      },
+    };
+  }
+}
+
+/**
+ * Handle /agents api-key-status command
+ */
+async function handleApiKeyStatus(
+  interaction: any,
+  channelId: string,
+  userId: string,
+  env: Env
+): Promise<InteractionResponse> {
+  const keyManager = createApiKeyManager(env.API_KEYS);
+  
+  // Check what API key would be used for agent creation
+  const userApiKey = await keyManager.getUserApiKey(userId);
+  const channelApiKey = await keyManager.getApiKey(channelId);
+  const hasDefaultKey = !!env.CURSOR_API_KEY;
+
+  let statusMessage = '🔍 **API Key Status**\n\n';
+  
+  if (userApiKey) {
+    statusMessage += '✅ **Personal API Key**: Set (will be used for your agents)\n';
+  } else {
+    statusMessage += '❌ **Personal API Key**: Not set\n';
+  }
+  
+  if (channelApiKey) {
+    statusMessage += '✅ **Channel API Key**: Set (will be used for agents when no personal key)\n';
+  } else {
+    statusMessage += '❌ **Channel API Key**: Not set\n';
+  }
+  
+  if (hasDefaultKey) {
+    statusMessage += '🔄 **Default API Key**: Available (fallback)\n';
+  } else {
+    statusMessage += '❌ **Default API Key**: Not configured\n';
+  }
+
+  statusMessage += '\n**For Agent Creation:**\n';
+  if (userApiKey) {
+    statusMessage += '→ Your personal API key will be used ✅';
+  } else if (channelApiKey) {
+    statusMessage += '→ Channel API key will be used 🏢';
+  } else if (hasDefaultKey) {
+    statusMessage += '→ Default API key will be used 🔄';
+  } else {
+    statusMessage += '→ ❌ No API key available - agents cannot be created';
+  }
+
+  statusMessage += '\n\n**For Thread Replies:**\n';
+  if (channelApiKey) {
+    statusMessage += '→ Channel API key will be used (priority) 🏢';
+  } else if (userApiKey) {
+    statusMessage += '→ Last replier\'s personal API key will be used 🔑';
+  } else if (hasDefaultKey) {
+    statusMessage += '→ Default API key will be used 🔄';
+  } else {
+    statusMessage += '→ ❌ No API key available - thread replies won\'t work';
+  }
+
+  return {
+    type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
+    data: {
+      content: statusMessage,
+      flags: 64, // Ephemeral
+    },
+  };
+}
+
+/**
  * Create agent asynchronously and send follow-up message to Discord
  */
 async function createAgentAsync(
@@ -655,9 +809,9 @@ async function createAgentAsync(
       throw new Error('Repository must be a valid GitHub URL (e.g., https://github.com/org/repo)');
     }
 
-    // Get API key for this channel
+    // Get API key using agent creation resolution logic
     const keyManager = createApiKeyManager(env.API_KEYS);
-    const apiKey = await getEffectiveApiKey(channelId, keyManager, env.CURSOR_API_KEY);
+    const apiKey = await keyManager.resolveApiKeyForAgent(channelId, userId, env.CURSOR_API_KEY);
 
     if (!apiKey) {
       throw new Error('No Cursor API key configured for this channel');
@@ -842,9 +996,9 @@ async function handleAgentLogs(
       return createErrorResponse('Agent not found in this channel');
     }
 
-    // Get API key for this channel
+    // Get API key for this channel (use channel-first resolution for existing agent operations)
     const keyManager = createApiKeyManager(env.API_KEYS);
-    const apiKey = await getEffectiveApiKey(channelId, keyManager, env.CURSOR_API_KEY);
+    const apiKey = await keyManager.resolveApiKeyForThread(channelId, agent.discordUserId, env.CURSOR_API_KEY);
 
       if (!apiKey) {
     return createErrorResponseWithButton(
@@ -903,13 +1057,19 @@ async function handleAgentsCommand(interaction: any, env: Env): Promise<Interact
 
   switch (subcommand?.name) {
     case AGENTS_SUBCOMMANDS.SET_API_KEY:
-      return await handleSetApiKey(interaction, channelId, userId, env);
+      const apiKeyType = subcommand.options?.find((opt: any) => opt.name === 'type')?.value;
+      return await handleSetApiKey(interaction, channelId, userId, apiKeyType, env);
     case AGENTS_SUBCOMMANDS.CREATE:
       return await handleCreateAgent(subcommand, channelId, userId, env);
     case AGENTS_SUBCOMMANDS.LIST:
       return await handleListAgents(subcommand, channelId, env);
     case AGENTS_SUBCOMMANDS.SET_DEFAULT_REPO:
       return await handleSetDefaultRepo(subcommand, channelId, env);
+    case AGENTS_SUBCOMMANDS.REMOVE_API_KEY:
+      const removeType = subcommand.options?.find((opt: any) => opt.name === 'type')?.value;
+      return await handleRemoveApiKey(interaction, channelId, userId, removeType, env);
+    case AGENTS_SUBCOMMANDS.API_KEY_STATUS:
+      return await handleApiKeyStatus(interaction, channelId, userId, env);
     default:
       return createErrorResponse('Unknown agents subcommand');
   }
@@ -1071,7 +1231,7 @@ async function handleDiscordInteraction(request: Request, env: Env, ctx: Executi
       
       if (componentData?.custom_id === 'set_api_key_button') {
         // Handle the "Set API Key" button click by showing the modal
-        response = await handleSetApiKey(interaction, componentChannelId, componentUserId, env);
+        response = await handleSetApiKey(interaction, componentChannelId, componentUserId, 'channel', env);
       } else if (componentData?.custom_id === 'set_default_repo_button') {
         // Handle the "Set Default Repository" button click by showing the modal
         response = await handleSetDefaultRepoButton(interaction, componentChannelId, componentUserId, env);


### PR DESCRIPTION
Add support for user-specific API keys and enhance key resolution logic for agents and threads.

This PR introduces a design for API key management that allows users to store personal keys in addition to existing channel keys. It defines a new resolution hierarchy: for agent creation, it prioritizes the requesting user's key, then the channel key; for thread replies, it prioritizes the channel key, then the key of the last user to reply in the thread.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9c363d2-463e-4c53-b459-982c1b44d87e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d9c363d2-463e-4c53-b459-982c1b44d87e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

