### PR TITLE
Add cursor web app url to agent creation thread message

### DIFF
--- a/examples/discord-cursor-bot-example/package-lock.json
+++ b/examples/discord-cursor-bot-example/package-lock.json
@@ -21,7 +21,7 @@
     },
     "../..": {
       "name": "vite-plugin-cloudflare-tunnel",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/discord-cursor-bot-example/src/thread-manager.ts
+++ b/examples/discord-cursor-bot-example/src/thread-manager.ts
@@ -75,11 +75,14 @@ export class ThreadManager {
    */
   private async sendInitialMessage(threadId: string, agentId: string, prompt: string): Promise<void> {
     try {
+      const cursorWebUrl = `https://cursor.com/agents?id=${agentId}`;
       const welcomeMessage = [
         `🚀 **Agent Created Successfully!**`,
         ``,
         `**Agent ID:** \`${agentId}\``,
         `**Task:** ${prompt}`,
+        ``,
+        `🌐 **View in Cursor Web App:** ${cursorWebUrl}`,
         ``,
         `I'll post updates here as the agent works on your task. Stay tuned! 👀`
       ].join('\n');

--- a/examples/discord-cursor-bot-example/src/worker.ts
+++ b/examples/discord-cursor-bot-example/src/worker.ts
@@ -569,7 +569,7 @@ async function handleCreateAgent(
     return {
       type: InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE,
       data: {
-        content: `🤖 **Agent Created!**\n\n**ID:** \`${agent.id}\`\n**Status:** ${agent.status}\n**Repository:** ${repository}\n\n${botToken ? '📡 Updates will be posted to the created thread.' : ''}`,
+        content: `🤖 **Agent Created!**\n\n**ID:** \`${agent.id}\`\n**Status:** ${agent.status}\n**Repository:** ${repository}\n\n🌐 **View in Cursor Web App:** https://cursor.com/agents?id=${agent.id}\n\n${botToken ? '📡 Updates will be posted to the created thread.' : ''}`,
       },
     };
 
@@ -691,7 +691,7 @@ async function createAgentAsync(
       }
     }
 
-    // const successMessage = `🤖 **Agent Created Successfully!**\n\n**ID:** \`${agent.id}\`\n**Status:** ${agent.status}\n**Repository:** ${repository}${threadInfo}`;
+    // const successMessage = `🤖 **Agent Created Successfully!**\n\n**ID:** \`${agent.id}\`\n**Status:** ${agent.status}\n**Repository:** ${repository}\n\n🌐 **View in Cursor Web App:** https://cursor.com/agents?id=${agent.id}${threadInfo}`;
     
     // await sendFollowUpMessage(channelId, successMessage, env);
   } catch (error) {


### PR DESCRIPTION
Add Cursor web app URL to agent creation messages in Discord bot example to provide direct access to agent instances.

---
<a href="https://cursor.com/background-agent?bcId=bc-c25a07fd-5638-4b75-9a82-5d257de36b28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c25a07fd-5638-4b75-9a82-5d257de36b28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

