### PR TITLE
Poll for new agent chat logs and update discord

### DIFF
--- a/examples/discord-cursor-bot-example/README.md
+++ b/examples/discord-cursor-bot-example/README.md
@@ -10,7 +10,10 @@ This combines Discord's [Interactions and Responding documentation](https://disc
 - 🔑 **Channel-specific API keys** stored securely in Cloudflare KV
 - 🧵 **Auto-created Discord threads** for each agent with real-time progress updates  
 - 📡 **Webhook integration** receives updates from Cursor API and posts to Discord
-- 💾 **D1 Database storage** for agent records and thread relationships
+- 🔄 **Intelligent polling fallback** - checks active agents every 2 minutes when webhooks fail
+- 💬 **Chat log streaming** - automatically posts new conversation messages to Discord threads
+- 📝 **Message deduplication** - tracks sent messages to avoid duplicates between webhooks and polling
+- 💾 **D1 Database storage** for agent records, thread relationships, and message tracking
 - ⚡ **Cloudflare Workers backend** - serverless, scalable, and fast
 - 🌐 **Public HTTPS endpoint** via Cloudflare Tunnel
 - 📊 **Simple web dashboard** to monitor agents across all channels
@@ -127,27 +130,61 @@ Discord Slash Commands
         ↓
 Cloudflare Worker (worker.ts)
         ↓
-┌─────────────────┬─────────────────┐
-│   KV Storage    │   D1 Database   │
-│ (API Keys by    │ (Agent Records) │
-│  Channel ID)    │                 │
-└─────────────────┴─────────────────┘
+┌─────────────────┬─────────────────────────────────────┐
+│   KV Storage    │           D1 Database               │
+│ (API Keys by    │ • Agent Records                     │
+│  Channel ID)    │ • Thread Message Tracking           │
+│                 │ • Polling Status & Webhook Health   │
+└─────────────────┴─────────────────────────────────────┘
         ↓
 Cursor API Integration (cursor-service.ts)
         ↓
+┌─────────────────────┬─────────────────────────────────┐
+│   Webhook Updates   │      Polling Service            │
+│   (Real-time)       │   (Every 2 minutes fallback)   │
+│                     │   • Fetches conversation logs  │
+│                     │   • Tracks sent messages       │
+│                     │   • Only when webhooks fail    │
+└─────────────────────┴─────────────────────────────────┘
+        ↓
 Discord Thread Updates (thread-manager.ts)
-(via Webhooks from webhook-handler.ts)
+• Status updates via webhooks
+• Chat messages via polling
+• Intelligent deduplication
 ```
 
 ### 📁 Code Structure
 
-- **`src/worker.ts`** - Main Cloudflare Worker handling Discord interactions
+- **`src/worker.ts`** - Main Cloudflare Worker handling Discord interactions and scheduled polling
 - **`src/thread-manager.ts`** - Discord thread creation and management
 - **`src/webhook-handler.ts`** - Cursor API webhook processing and Discord updates
+- **`src/polling-service.ts`** - Intelligent polling service for active agents (fallback when webhooks fail)
 - **`src/cursor-service.ts`** - Cursor Background Agents API integration
 - **`src/discord-commands.ts`** - Discord slash command definitions
 - **`src/types.ts`** - TypeScript interfaces for the application
 - **`src/cursor-api-types.ts`** - Cursor API specific type definitions
+
+## 🔄 Polling System
+
+The bot includes an intelligent polling system that automatically kicks in when webhook updates are not available:
+
+### How It Works
+1. **Webhook Priority**: When agents are created, webhooks provide real-time status updates
+2. **Automatic Fallback**: If webhooks stop working (network issues, API problems), polling activates after 5 minutes
+3. **Smart Polling**: Only polls agents that haven't received webhook updates recently
+4. **Message Tracking**: Tracks which conversation messages have been sent to avoid duplicates
+5. **Conversation Streaming**: Fetches latest chat logs and posts new messages to Discord threads
+
+### Polling Features
+- **Frequency**: Every 2 minutes for active agents (`CREATING`, `PENDING`, `RUNNING`)
+- **Batch Processing**: Processes 3 agents at a time to respect rate limits
+- **Deduplication**: Database tracking prevents duplicate messages between webhooks and polling
+- **Automatic Cleanup**: Removes completed agents from polling table
+- **Webhook Recovery**: Automatically switches back to webhooks when they become available
+
+### Database Tables
+- **`active_agents_polling`**: Tracks polling status and webhook health for each agent
+- **`agent_thread_messages`**: Records which messages have been sent to Discord to prevent duplicates
 
 ## 🛠️ Development
 
@@ -168,6 +205,12 @@ npm run db:migrate:prod
 
 # View data
 wrangler d1 execute discord-cursor-agents --local --command="SELECT * FROM agents"
+
+# View polling status
+wrangler d1 execute discord-cursor-agents --local --command="SELECT * FROM active_agents_polling"
+
+# View message tracking
+wrangler d1 execute discord-cursor-agents --local --command="SELECT * FROM agent_thread_messages ORDER BY sent_at DESC LIMIT 10"
 ```
 
 ### Production Deployment

--- a/examples/discord-cursor-bot-example/migrations/0002_add_message_tracking.sql
+++ b/examples/discord-cursor-bot-example/migrations/0002_add_message_tracking.sql
@@ -1,0 +1,36 @@
+-- migrations/0002_add_message_tracking.sql
+-- Add table to track which agent messages have been sent to Discord threads
+
+-- Create agent_thread_messages table to track sent messages
+CREATE TABLE IF NOT EXISTS agent_thread_messages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT NOT NULL,
+  message_index INTEGER NOT NULL,
+  message_content TEXT NOT NULL,
+  message_role TEXT NOT NULL,
+  discord_message_id TEXT,
+  sent_at TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(agent_id, message_index)
+);
+
+-- Create indexes for better performance
+CREATE INDEX IF NOT EXISTS idx_agent_thread_messages_agent_id ON agent_thread_messages(agent_id);
+CREATE INDEX IF NOT EXISTS idx_agent_thread_messages_sent_at ON agent_thread_messages(sent_at);
+
+-- Create active_agents_polling table to track polling status
+CREATE TABLE IF NOT EXISTS active_agents_polling (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT UNIQUE NOT NULL,
+  status TEXT NOT NULL,
+  last_polled_at TEXT NOT NULL,
+  last_message_index INTEGER DEFAULT 0,
+  webhook_active BOOLEAN DEFAULT TRUE,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Create indexes for polling table
+CREATE INDEX IF NOT EXISTS idx_active_agents_polling_status ON active_agents_polling(status);
+CREATE INDEX IF NOT EXISTS idx_active_agents_polling_last_polled ON active_agents_polling(last_polled_at);
+CREATE INDEX IF NOT EXISTS idx_active_agents_polling_webhook_active ON active_agents_polling(webhook_active);

--- a/examples/discord-cursor-bot-example/package-lock.json
+++ b/examples/discord-cursor-bot-example/package-lock.json
@@ -21,7 +21,7 @@
     },
     "../..": {
       "name": "vite-plugin-cloudflare-tunnel",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/examples/discord-cursor-bot-example/src/polling-service.ts
+++ b/examples/discord-cursor-bot-example/src/polling-service.ts
@@ -1,0 +1,389 @@
+/**
+ * Polling Service for Discord Cursor Bot
+ * 
+ * This service polls active agents every 2 minutes to check for new chat messages
+ * when webhook updates are not available. It tracks which messages have been sent
+ * to avoid duplicates and updates Discord threads with new conversation logs.
+ */
+
+import { CursorApiService } from './cursor-service';
+import { ThreadManager } from './thread-manager';
+import { getEffectiveApiKey, createApiKeyManager } from './api-key-manager';
+import type { 
+  Env, 
+  StoredCursorAgent, 
+  AgentDatabaseRow 
+} from './types';
+import { dbRowToStoredAgent } from './types';
+
+interface AgentThreadMessage {
+  id: number;
+  agent_id: string;
+  message_index: number;
+  message_content: string;
+  message_role: string;
+  discord_message_id: string | null;
+  sent_at: string;
+  created_at: string;
+}
+
+interface ActiveAgentPolling {
+  id: number;
+  agent_id: string;
+  status: string;
+  last_polled_at: string;
+  last_message_index: number;
+  webhook_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ConversationMessage {
+  role: string;
+  content: string;
+  timestamp?: string;
+}
+
+export class PollingService {
+  constructor(private env: Env) {}
+
+  /**
+   * Get Discord bot token from environment
+   */
+  private getDiscordBotToken(): string | null {
+    return this.env.DISCORD_BOT_TOKEN || null;
+  }
+
+  /**
+   * Get all active agents that need polling (where webhooks are not working)
+   */
+  private async getActiveAgents(): Promise<StoredCursorAgent[]> {
+    try {
+      // Get active agents where webhooks haven't been active in the last 5 minutes
+      // This gives webhooks time to work before falling back to polling
+      const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      
+      const result = await this.env.DB.prepare(`
+        SELECT a.* FROM agents a
+        LEFT JOIN active_agents_polling p ON a.id = p.agent_id
+        WHERE a.status IN ('CREATING', 'PENDING', 'RUNNING')
+        AND a.discord_thread_id IS NOT NULL
+        AND (
+          p.agent_id IS NULL 
+          OR p.webhook_active = FALSE 
+          OR p.updated_at < ?
+        )
+        ORDER BY a.updated_at DESC
+      `).bind(fiveMinutesAgo).all<AgentDatabaseRow>();
+
+      return (result.results || []).map(dbRowToStoredAgent);
+    } catch (error) {
+      console.error('❌ Failed to get active agents:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Get or create polling record for an agent
+   */
+  private async getOrCreatePollingRecord(agentId: string, status: string): Promise<ActiveAgentPolling | null> {
+    try {
+      // Try to get existing record
+      const existing = await this.env.DB.prepare(`
+        SELECT * FROM active_agents_polling WHERE agent_id = ?
+      `).bind(agentId).first<ActiveAgentPolling>();
+
+      if (existing) {
+        return existing;
+      }
+
+      // Create new record
+      const now = new Date().toISOString();
+      await this.env.DB.prepare(`
+        INSERT INTO active_agents_polling (agent_id, status, last_polled_at, last_message_index, webhook_active)
+        VALUES (?, ?, ?, ?, ?)
+      `).bind(agentId, status, now, 0, true).run();
+
+      // Return the newly created record
+      return await this.env.DB.prepare(`
+        SELECT * FROM active_agents_polling WHERE agent_id = ?
+      `).bind(agentId).first<ActiveAgentPolling>();
+    } catch (error) {
+      console.error(`❌ Failed to get/create polling record for agent ${agentId}:`, error);
+      return null;
+    }
+  }
+
+  /**
+   * Update polling record with latest poll time and message index
+   */
+  private async updatePollingRecord(agentId: string, status: string, lastMessageIndex: number): Promise<void> {
+    try {
+      const now = new Date().toISOString();
+      await this.env.DB.prepare(`
+        UPDATE active_agents_polling 
+        SET status = ?, last_polled_at = ?, last_message_index = ?, webhook_active = FALSE, updated_at = ?
+        WHERE agent_id = ?
+      `).bind(status, now, lastMessageIndex, now, agentId).run();
+    } catch (error) {
+      console.error(`❌ Failed to update polling record for agent ${agentId}:`, error);
+    }
+  }
+
+  /**
+   * Check if a message has already been sent to Discord
+   */
+  private async isMessageAlreadySent(agentId: string, messageIndex: number): Promise<boolean> {
+    try {
+      const result = await this.env.DB.prepare(`
+        SELECT id FROM agent_thread_messages 
+        WHERE agent_id = ? AND message_index = ?
+      `).bind(agentId, messageIndex).first();
+
+      return !!result;
+    } catch (error) {
+      console.error(`❌ Failed to check if message exists for agent ${agentId}:`, error);
+      return false;
+    }
+  }
+
+  /**
+   * Record that a message was sent to Discord
+   */
+  private async recordSentMessage(
+    agentId: string, 
+    messageIndex: number, 
+    message: ConversationMessage,
+    discordMessageId?: string
+  ): Promise<void> {
+    try {
+      const now = new Date().toISOString();
+      await this.env.DB.prepare(`
+        INSERT INTO agent_thread_messages (
+          agent_id, message_index, message_content, message_role, discord_message_id, sent_at
+        ) VALUES (?, ?, ?, ?, ?, ?)
+      `).bind(
+        agentId, 
+        messageIndex, 
+        message.content, 
+        message.role, 
+        discordMessageId || null, 
+        now
+      ).run();
+    } catch (error) {
+      console.error(`❌ Failed to record sent message for agent ${agentId}:`, error);
+    }
+  }
+
+  /**
+   * Format conversation message for Discord
+   */
+  private formatMessageForDiscord(message: ConversationMessage, index: number): string {
+    const roleEmojis: Record<string, string> = {
+      'user': '👤',
+      'assistant': '🤖',
+      'system': '⚙️',
+      'tool': '🔧'
+    };
+
+    const emoji = roleEmojis[message.role] || '💬';
+    const timestamp = message.timestamp ? new Date(message.timestamp).toLocaleTimeString() : '';
+    
+    // Truncate very long messages for Discord
+    const content = message.content.length > 1500 
+      ? message.content.slice(0, 1500) + '...\n\n*[Message truncated for Discord]*' 
+      : message.content;
+
+    return [
+      `${emoji} **${message.role.charAt(0).toUpperCase() + message.role.slice(1)}${timestamp ? ` (${timestamp})` : ''}**`,
+      '',
+      content,
+      '',
+      `*Message #${index + 1}*`
+    ].join('\n');
+  }
+
+  /**
+   * Process new messages for an agent and send to Discord
+   */
+  private async processNewMessages(
+    agent: StoredCursorAgent,
+    pollingRecord: ActiveAgentPolling,
+    messages: ConversationMessage[]
+  ): Promise<void> {
+    if (!agent.discordThreadId) {
+      console.log(`⚠️ Agent ${agent.id} has no Discord thread`);
+      return;
+    }
+
+    const botToken = this.getDiscordBotToken();
+    if (!botToken) {
+      console.log('⚠️ No Discord bot token configured, skipping message updates');
+      return;
+    }
+
+    const threadManager = new ThreadManager(botToken);
+    const startIndex = pollingRecord.last_message_index;
+    const newMessages = messages.slice(startIndex);
+
+    if (newMessages.length === 0) {
+      console.log(`📝 No new messages for agent ${agent.id.slice(-8)}`);
+      return;
+    }
+
+    console.log(`📬 Found ${newMessages.length} new messages for agent ${agent.id.slice(-8)}`);
+
+    // Send new messages to Discord thread
+    for (let i = 0; i < newMessages.length; i++) {
+      const messageIndex = startIndex + i;
+      const message = newMessages[i];
+
+      // Skip if already sent (extra safety check)
+      if (await this.isMessageAlreadySent(agent.id, messageIndex)) {
+        console.log(`⏭️ Message ${messageIndex} already sent for agent ${agent.id.slice(-8)}`);
+        continue;
+      }
+
+      try {
+        const formattedMessage = this.formatMessageForDiscord(message, messageIndex);
+        await threadManager.sendMessageToThread(agent.discordThreadId, formattedMessage);
+        
+        // Record that we sent this message
+        await this.recordSentMessage(agent.id, messageIndex, message);
+        
+        console.log(`✅ Sent message ${messageIndex} to thread for agent ${agent.id.slice(-8)}`);
+        
+        // Add small delay between messages to avoid rate limits
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      } catch (error) {
+        console.error(`❌ Failed to send message ${messageIndex} for agent ${agent.id}:`, error);
+        // Continue with other messages even if one fails
+      }
+    }
+
+    // Update polling record with new message count
+    await this.updatePollingRecord(agent.id, agent.status, messages.length);
+  }
+
+  /**
+   * Poll a single agent for new messages
+   */
+  private async pollAgent(agent: StoredCursorAgent): Promise<void> {
+    console.log(`🔍 Polling agent ${agent.id.slice(-8)} for new messages...`);
+
+    try {
+      // Get or create polling record
+      const pollingRecord = await this.getOrCreatePollingRecord(agent.id, agent.status);
+      if (!pollingRecord) {
+        console.error(`❌ Could not get polling record for agent ${agent.id}`);
+        return;
+      }
+
+      // Get API key for the channel
+      const keyManager = createApiKeyManager(this.env.API_KEYS);
+      const apiKey = await getEffectiveApiKey(agent.discordChannelId, keyManager, this.env.CURSOR_API_KEY);
+
+      if (!apiKey) {
+        console.log(`⚠️ No API key available for agent ${agent.id} in channel ${agent.discordChannelId}`);
+        return;
+      }
+
+      // Fetch conversation from Cursor API
+      const cursorService = new CursorApiService(apiKey);
+      const conversation = await cursorService.getAgentConversation(agent.id);
+
+      if (!conversation.messages || conversation.messages.length === 0) {
+        console.log(`📭 No conversation messages found for agent ${agent.id.slice(-8)}`);
+        await this.updatePollingRecord(agent.id, agent.status, 0);
+        return;
+      }
+
+      // Process new messages
+      await this.processNewMessages(agent, pollingRecord, conversation.messages);
+
+    } catch (error) {
+      console.error(`❌ Failed to poll agent ${agent.id}:`, error);
+      
+      // If API call fails, it might be because webhook is down
+      // Continue polling this agent
+      try {
+        await this.updatePollingRecord(agent.id, agent.status, 0);
+      } catch (updateError) {
+        console.error(`❌ Failed to update polling record after error:`, updateError);
+      }
+    }
+  }
+
+  /**
+   * Mark agents as completed/inactive when they're no longer active
+   */
+  private async cleanupInactiveAgents(): Promise<void> {
+    try {
+      // Get agents that are no longer active but still in polling table
+      const result = await this.env.DB.prepare(`
+        SELECT p.agent_id, p.status as polling_status, a.status as current_status
+        FROM active_agents_polling p
+        LEFT JOIN agents a ON p.agent_id = a.id
+        WHERE a.status NOT IN ('CREATING', 'PENDING', 'RUNNING')
+        OR a.id IS NULL
+      `).all();
+
+      for (const row of result.results || []) {
+        console.log(`🧹 Cleaning up inactive agent ${row.agent_id}`);
+        
+        // Remove from polling table
+        await this.env.DB.prepare(`
+          DELETE FROM active_agents_polling WHERE agent_id = ?
+        `).bind(row.agent_id).run();
+      }
+    } catch (error) {
+      console.error('❌ Failed to cleanup inactive agents:', error);
+    }
+  }
+
+  /**
+   * Main polling function - checks all active agents for new messages
+   */
+  async pollActiveAgents(): Promise<void> {
+    console.log('🔄 Starting polling cycle for active agents...');
+
+    try {
+      // Get all active agents
+      const activeAgents = await this.getActiveAgents();
+      
+      if (activeAgents.length === 0) {
+        console.log('📭 No active agents found for polling');
+        return;
+      }
+
+      console.log(`📊 Found ${activeAgents.length} active agents to poll`);
+
+      // Poll each agent (with some parallelism but not too much to avoid rate limits)
+      const batchSize = 3; // Process 3 agents at a time
+      for (let i = 0; i < activeAgents.length; i += batchSize) {
+        const batch = activeAgents.slice(i, i + batchSize);
+        await Promise.allSettled(batch.map(agent => this.pollAgent(agent)));
+        
+        // Small delay between batches
+        if (i + batchSize < activeAgents.length) {
+          await new Promise(resolve => setTimeout(resolve, 2000));
+        }
+      }
+
+      // Cleanup inactive agents
+      await this.cleanupInactiveAgents();
+
+      console.log('✅ Polling cycle completed');
+
+    } catch (error) {
+      console.error('❌ Error during polling cycle:', error);
+    }
+  }
+}
+
+/**
+ * Create a polling service instance
+ */
+export function createPollingService(env: Env): PollingService {
+  return new PollingService(env);
+}

--- a/examples/discord-cursor-bot-example/src/webhook-handler.ts
+++ b/examples/discord-cursor-bot-example/src/webhook-handler.ts
@@ -72,6 +72,31 @@ export class WebhookHandler {
   }
 
   /**
+   * Mark webhook as active for an agent (so polling knows webhook is working)
+   */
+  private async markWebhookActive(agentId: string): Promise<void> {
+    try {
+      const now = new Date().toISOString();
+      // Try to update existing record first
+      const result = await this.env.DB.prepare(`
+        UPDATE active_agents_polling 
+        SET webhook_active = TRUE, updated_at = ?
+        WHERE agent_id = ?
+      `).bind(now, agentId).run();
+
+      // If no rows were updated, insert a new record
+      if (result.changes === 0) {
+        await this.env.DB.prepare(`
+          INSERT INTO active_agents_polling (agent_id, status, last_polled_at, last_message_index, webhook_active, updated_at)
+          VALUES (?, 'WEBHOOK_ACTIVE', ?, 0, TRUE, ?)
+        `).bind(agentId, now, now).run();
+      }
+    } catch (error) {
+      console.error(`❌ Failed to mark webhook active for agent ${agentId}:`, error);
+    }
+  }
+
+  /**
    * Process a Cursor webhook event and update Discord accordingly
    */
   async processWebhookEvent(event: CursorWebhookEvent): Promise<void> {
@@ -82,6 +107,9 @@ export class WebhookHandler {
     });
 
     try {
+      // Mark webhook as active for this agent
+      await this.markWebhookActive(event.id);
+
       // Update agent status in database
       await this.updateAgentStatus(
         event.id, 

--- a/examples/discord-cursor-bot-example/src/worker.ts
+++ b/examples/discord-cursor-bot-example/src/worker.ts
@@ -20,6 +20,7 @@ import { ThreadManager, createThreadManager } from './thread-manager';
 import { handleCursorWebhook } from './webhook-handler';
 import { handleThreadInteraction } from './thread-interaction-handler';
 import { ApiKeyManager, createApiKeyManager, getEffectiveApiKey } from './api-key-manager';
+import { createPollingService } from './polling-service';
 import type { 
   Env, 
   InteractionResponse, 
@@ -1239,6 +1240,20 @@ async function handleFetch(request: Request, env: Env, ctx: ExecutionContext): P
 }
 
 /**
+ * Handle scheduled events (cron jobs) for polling active agents
+ */
+async function handleScheduled(event: any, env: Env, ctx: ExecutionContext): Promise<void> {
+  console.log('⏰ Scheduled event triggered:', event.cron);
+  
+  try {
+    const pollingService = createPollingService(env);
+    await pollingService.pollActiveAgents();
+  } catch (error) {
+    console.error('❌ Error in scheduled polling:', error);
+  }
+}
+
+/**
  * Main worker export
  */
 export default {
@@ -1246,5 +1261,9 @@ export default {
     const response = await handleFetch(request, env, ctx);
     console.log('🔒 Response:', response.status);
     return response;
+  },
+
+  async scheduled(event: any, env: Env, ctx: ExecutionContext): Promise<void> {
+    return await handleScheduled(event, env, ctx);
   },
 };

--- a/examples/discord-cursor-bot-example/wrangler.toml
+++ b/examples/discord-cursor-bot-example/wrangler.toml
@@ -27,3 +27,7 @@ id = "82f4f91af5314fc4a25006431c98d5f6"
 [assets]
 run_worker_first = false
 not_found_handling = "single-page-application"
+
+# Scheduled events for polling active agents every 2 minutes
+[triggers]
+crons = ["*/2 * * * *"]


### PR DESCRIPTION
Add intelligent polling to update Discord threads with agent chat logs when webhooks are inactive.

This provides a robust fallback mechanism, using D1 to track active agents and previously sent messages, ensuring continuity and deduplication of updates in Discord threads, and automatically activating when webhooks are not reporting.

---
<a href="https://cursor.com/background-agent?bcId=bc-012816af-6d45-4416-9ecd-756b4bcd4397">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-012816af-6d45-4416-9ecd-756b4bcd4397">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

